### PR TITLE
ganix: GCE Arm NixOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,6 +96,20 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
     "formatter-nvim": {
       "flake": false,
       "locked": {
@@ -115,11 +129,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1669826718,
-        "narHash": "sha256-2S25m5sx7fHI/PHKosch7w/uV7DUOFtOQVpp9sUGKYk=",
+        "lastModified": 1671195647,
+        "narHash": "sha256-lu4wPfPhcVwzMwbrgtoxyrhcRkMUPXu5JKAaK5w6/Q0=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "d076301a634198e0ae3efee3b298fc63c055a871",
+        "rev": "71644a2907adc076f1c5e712f59d897f5197d5d6",
         "type": "github"
       },
       "original": {
@@ -136,11 +150,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1670156115,
-        "narHash": "sha256-L2FKLedprp3AkQ+GS+2Br7CYWeCmLCjt3zUd87p0lNQ=",
+        "lastModified": 1670253003,
+        "narHash": "sha256-/tJIy4+FbsQyslq1ipyicZ2psOEd8dvl4OJ9lfisjd0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e704ef9ec7a8ccf8711bb11ff68da06f1917a26d",
+        "rev": "0e8125916b420e41bf0d23a0aa33fadd0328beb3",
         "type": "github"
       },
       "original": {
@@ -185,11 +199,11 @@
     "luasnip": {
       "flake": false,
       "locked": {
-        "lastModified": 1669931093,
-        "narHash": "sha256-h0FTlWJ1BH9Vw3RG9l1JWtBmaNwn0bfCe0mm33cYsb8=",
+        "lastModified": 1670761649,
+        "narHash": "sha256-IDes6O85repb3Z4GSynXDEKbRlN2j8hhCX5SOipi/HI=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "bc9ba285be806cd8f1db9e7dbd50e33a300e11c2",
+        "rev": "8b25e74761eead3dc47ce04b5e017fd23da7ad7e",
         "type": "github"
       },
       "original": {
@@ -201,11 +215,11 @@
     "neogit": {
       "flake": false,
       "locked": {
-        "lastModified": 1669628174,
-        "narHash": "sha256-amSBOSOHw8oDsyVKa7hTyfu3L6/bSJrrcht/XvY4u+k=",
+        "lastModified": 1671035017,
+        "narHash": "sha256-obmvJYtDV+ADLaOWAmaceuqj6T8z9mIZubFEQVv4fdI=",
         "owner": "TimUntersberger",
         "repo": "neogit",
-        "rev": "74e14e3c885f0caf64004d1c1e75dcbef96e10e5",
+        "rev": "0d6002c6af432343937283fb70791fc76fa7227c",
         "type": "github"
       },
       "original": {
@@ -216,11 +230,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670163909,
-        "narHash": "sha256-aPoxv+IdfY8S/4OMsDCdoYGFvKvXHvXDCAw9GpM1bes=",
+        "lastModified": 1671282711,
+        "narHash": "sha256-DJknmGMZPIMlJnLqP99A+dZiWOirRVeCZrQK8kn1nug=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dcb3a0712b7606518f926e3e312a27e0dbb0a610",
+        "rev": "8ac4d14fc64c39707e98421e84ed6a7160c06ecd",
         "type": "github"
       },
       "original": {
@@ -232,11 +246,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1670086663,
-        "narHash": "sha256-hT8C8AQB74tdoCPwz4nlJypLMD7GI2F5q+vn+VE/qQk=",
+        "lastModified": 1671249438,
+        "narHash": "sha256-5e+CcnbZA3/i2BRXbnzRS52Ly67MUNdZR+Zpbb2C65k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "813836d64fa57285d108f0dbf2356457ccd304e3",
+        "rev": "067bfc6c90a301572cec7da48f09c447a9a8eae0",
         "type": "github"
       },
       "original": {
@@ -249,11 +263,11 @@
     "null-ls-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1669991088,
-        "narHash": "sha256-DZgonVEzkgayvLY9jkEH1O/Xny6LQktyi8rTNbQlkMk=",
+        "lastModified": 1671050150,
+        "narHash": "sha256-W9VvDvzabFmfntlwg43nhAXg9tB5LDAL9JvILxvRZm0=",
         "owner": "jose-elias-alvarez",
         "repo": "null-ls.nvim",
-        "rev": "a67897283fdb0051ad5c72e840e1845e195b979b",
+        "rev": "5d8e925d31d8ef8462832308c016ac4ace17597a",
         "type": "github"
       },
       "original": {
@@ -265,11 +279,11 @@
     "nvim-bqf": {
       "flake": false,
       "locked": {
-        "lastModified": 1669127777,
-        "narHash": "sha256-MrgPxHTWF0ihi8hwlObpEWVu2a3C3B0Z7NAPipTyqyw=",
+        "lastModified": 1670210900,
+        "narHash": "sha256-TuCrZe2pMxGG21RsCPnYU6ysGtoM/PxsnscWFoVnLlE=",
         "owner": "kevinhwang91",
         "repo": "nvim-bqf",
-        "rev": "448fa92e7f3838e3b5adbce58b55c5f97a6d2cec",
+        "rev": "3389264042e4590ed32ce26d7e47b17ec4e6e6d5",
         "type": "github"
       },
       "original": {
@@ -281,11 +295,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1669562650,
-        "narHash": "sha256-zNXpUM55ylCzEngj4L9kPuGq1v6x4xeK3MldsnIYKTE=",
+        "lastModified": 1671103622,
+        "narHash": "sha256-heftWvwb/FpOpNCWqf9KgXyy11G30UMaOlUp86/eq9E=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "93f385c17611039f3cc35e1399f1c0a8cf82f1fb",
+        "rev": "8bbaeda725d5db6e4e1be2867a64b43bf547cf06",
         "type": "github"
       },
       "original": {
@@ -297,11 +311,11 @@
     "nvim-dap": {
       "flake": false,
       "locked": {
-        "lastModified": 1669893484,
-        "narHash": "sha256-4Q5Bm+Mq0iVraCgUAe9QkJvkVxkXMSVZBq7gompMdEk=",
+        "lastModified": 1670867307,
+        "narHash": "sha256-od5ILdUqRSBHMDuPXR+VMVVJJoO1+F3SI85CFwybYk0=",
         "owner": "mfussenegger",
         "repo": "nvim-dap",
-        "rev": "8f396b7836b9bbda9edd9f655f12ca377ae97676",
+        "rev": "68d96871118a13365f3c33e4838990030fff80ec",
         "type": "github"
       },
       "original": {
@@ -329,11 +343,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1670149240,
-        "narHash": "sha256-aGm92vw9lDcGLFOsNAyYrrzIfga13fWVrXuFiOqXuUQ=",
+        "lastModified": 1671149856,
+        "narHash": "sha256-oFQknQ03UBXrpWelfTZdnAdnkNMTG0SOyJEmKYaQtac=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "ac132be91a6a8170788e7139964288e673b31c5e",
+        "rev": "e95c12cea141632d3502fad4fb1c9260a91a65f4",
         "type": "github"
       },
       "original": {
@@ -345,11 +359,11 @@
     "nvim-tree-lua": {
       "flake": false,
       "locked": {
-        "lastModified": 1670039798,
-        "narHash": "sha256-mQfo9KlNHbZtDIO3U8BZ7PGVBP5EtLUDpETq+bfqpVU=",
+        "lastModified": 1671257133,
+        "narHash": "sha256-113KjDFwxhfzK+t6TVHv8WPsty5Fbrxw964rjXvxnmw=",
         "owner": "kyazdani42",
         "repo": "nvim-tree.lua",
-        "rev": "f8489c992998e1e1b45aec65bdb9615e5cd59a61",
+        "rev": "29788cc32a153e42b2fe48344d315da8367fc6fa",
         "type": "github"
       },
       "original": {
@@ -361,11 +375,11 @@
     "nvim-treesitter": {
       "flake": false,
       "locked": {
-        "lastModified": 1670151400,
-        "narHash": "sha256-pkLtMvqRm6q5dOrawb7bKZCpoVBcEbFh/joMEJujyyY=",
+        "lastModified": 1671278949,
+        "narHash": "sha256-TR1zFaWmxALJUbNcr6BhAmhGe1pRxyH4He2WKe50C8o=",
         "owner": "nvim-treesitter",
         "repo": "nvim-treesitter",
-        "rev": "e71dfc1e7a3e7a7782a3c5e62e7de5993149a261",
+        "rev": "2603f1d4316acb0e569d1cdf04c631e867468e37",
         "type": "github"
       },
       "original": {
@@ -393,11 +407,11 @@
     "nvim-web-devicons": {
       "flake": false,
       "locked": {
-        "lastModified": 1669423115,
-        "narHash": "sha256-Wyd4HnV+aQrh4Z2KdwCdi84glzIbQt8/y7NRGf67hcw=",
+        "lastModified": 1670623994,
+        "narHash": "sha256-X2CM/CjBS5RCKVsepbOnmmYveYNjssaMm8uo92u2o6w=",
         "owner": "kyazdani42",
         "repo": "nvim-web-devicons",
-        "rev": "189ad3790d57c548896a78522fd8b0d0fc11be31",
+        "rev": "05e1072f63f6c194ac6e867b567e6b437d3d4622",
         "type": "github"
       },
       "original": {
@@ -430,6 +444,7 @@
         "cmp-nvim-lua": "cmp-nvim-lua",
         "cmp-path": "cmp-path",
         "cmp_luasnip": "cmp_luasnip",
+        "flake-utils": "flake-utils",
         "formatter-nvim": "formatter-nvim",
         "gitsigns-nvim": "gitsigns-nvim",
         "home-manager": "home-manager",
@@ -483,11 +498,11 @@
     "tcomment_vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1670000106,
-        "narHash": "sha256-nmr2nBu0jvc2mV2g3zE7qYUqyJOVBKWJ+w61mxEWWOA=",
+        "lastModified": 1671254443,
+        "narHash": "sha256-fe8A6MWfk8CgpkjwCswT9uz01f3s5LUYtU8O2LO11Bo=",
         "owner": "tomtom",
         "repo": "tcomment_vim",
-        "rev": "ced243a049bb6839ff057741de731418879e97e8",
+        "rev": "b4930f9da28647e5417d462c341013f88184be7e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -218,62 +218,70 @@
       # https://nixos.org/manual/nix/stable/language/constructs.html#functions
       # An @-pattern provides a means of referring to the whole value being matched
     } @ inputs:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
+    let
+      # https://nixos.wiki/wiki/Flakes#Importing_packages_from_multiple_channels
+      overlay-unstable = system: final: prev: {
+        unstable = import nixpkgs-unstable {
+          inherit system;
+          inputs.nixpkgs.config.allowUnfree = true;
+        };
+      };
 
-        # https://nixos.wiki/wiki/Flakes#Importing_packages_from_multiple_channels
-        overlay-unstable = final: prev: {
-          unstable = import nixpkgs-unstable {
-            inherit system;
-            inputs.nixpkgs.config.allowUnfree = true;
-          };
+      vimPlugins = {
+        inherit (inputs) base16-vim-mccurdyc;
+      };
+
+      mkSystem =
+        { nixpkgs ? inputs.nixpkgs-unstable
+        , system
+        , hostname
+        ,
+        }:
+        nixpkgs.lib.nixosSystem {
+          inherit system;
+
+          # replaces the older configuration.nix
+          modules = [
+            { networking.hostName = hostname; }
+
+            # General configuration (users, networking, sound, etc)
+            ./modules/system/configuration.nix
+
+            # Hardware config (bootloader, kernel modules, filesystems, etc)
+            (./. + "/hosts/${hostname}/hardware-configuration.nix")
+
+            home-manager.nixosModules.home-manager
+            {
+              home-manager = {
+                useUserPackages = true;
+                useGlobalPkgs = true;
+                extraSpecialArgs = { inherit inputs; };
+                users.mccurdyc = ./. + "/hosts/${hostname}/user.nix";
+              };
+            }
+            {
+              nixpkgs.overlays = [
+                (import ./overlays/vim-plugins.nix nixpkgs vimPlugins system)
+                (overlay-unstable system)
+              ];
+            }
+          ];
+          # WHY?
+          # specialArgs = { inherit self inputs nixpkgs; };
+        };
+    in
+    {
+      nixosConfigurations = {
+        nuc = mkSystem {
+          system = "x86_64-linux";
+          hostname = "nuc";
         };
 
-        vimPlugins = {
-          inherit (inputs) base16-vim-mccurdyc;
+        # GCE Arm Nix
+        ganix = mkSystem {
+          system = "aarch64-linux";
+          hostname = "ganix";
         };
-
-        mkSystem = pkgs: system: hostname:
-          pkgs.lib.nixosSystem {
-            inherit system;
-
-            # replaces the older configuration.nix
-            modules = [
-              { networking.hostName = hostname; }
-
-              # General configuration (users, networking, sound, etc)
-              ./modules/system/configuration.nix
-
-              # Hardware config (bootloader, kernel modules, filesystems, etc)
-              (./. + "/hosts/${hostname}/hardware-configuration.nix")
-
-              home-manager.nixosModules.home-manager
-              {
-                home-manager = {
-                  useUserPackages = true;
-                  useGlobalPkgs = true;
-                  extraSpecialArgs = { inherit inputs; };
-                  users.mccurdyc = ./. + "/hosts/${hostname}/user.nix";
-                };
-              }
-              {
-                nixpkgs.overlays = [
-                  (import ./overlays/vim-plugins.nix nixpkgs vimPlugins system)
-                  overlay-unstable
-                ];
-              }
-            ];
-            specialArgs = { inherit inputs; };
-          };
-      in
-      {
-        nixosConfigurations = {
-          nuc = mkSystem inputs.nixpkgs "x86_64-linux" "nuc";
-          # GCE Arm Nix
-          ganix = mkSystem inputs.nixpkgs "aarch64-linux" "ganix";
-        };
-      }
-      );
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -238,13 +238,17 @@
         mkSystem = pkgs: system: hostname:
           pkgs.lib.nixosSystem {
             inherit system;
+
             # replaces the older configuration.nix
             modules = [
               { networking.hostName = hostname; }
+
               # General configuration (users, networking, sound, etc)
               ./modules/system/configuration.nix
+
               # Hardware config (bootloader, kernel modules, filesystems, etc)
               (./. + "/hosts/${hostname}/hardware-configuration.nix")
+
               home-manager.nixosModules.home-manager
               {
                 home-manager = {
@@ -267,6 +271,8 @@
       {
         nixosConfigurations = {
           nuc = mkSystem inputs.nixpkgs "x86_64-linux" "nuc";
+          # GCE Arm Nix
+          ganix = mkSystem inputs.nixpkgs "aarch64-linux" "ganix";
         };
       }
       );

--- a/hosts/ganix/hardware-configuration.nix
+++ b/hosts/ganix/hardware-configuration.nix
@@ -40,9 +40,6 @@ with lib;
   services.udev.packages = [ pkgs.google-guest-configs ];
   services.udev.path = [ pkgs.google-guest-configs ];
 
-  # Force getting the hostname from Google Compute.
-  networking.hostName = "fastly-nixos";
-
   environment.systemPackages = [
     pkgs.git
     pkgs.mosh

--- a/hosts/ganix/hardware-configuration.nix
+++ b/hosts/ganix/hardware-configuration.nix
@@ -52,9 +52,6 @@ with lib;
     pkgs.zsh
   ];
 
-  # Rely on GCP's firewall instead
-  networking.firewall.enable = false;
-
   # At this point, we are past packer, so we can just rely on tailscale.
   services.openssh.enable = false;
   services.openssh.permitRootLogin = "prohibit-password";

--- a/hosts/ganix/hardware-configuration.nix
+++ b/hosts/ganix/hardware-configuration.nix
@@ -1,0 +1,113 @@
+# Copied from my GCE, packer-built nixos image.
+# Which mostly just takes from here - https://github.com/NixOS/nixpkgs/blob/nixos-22.11/nixos/modules/virtualisation/google-compute-config.nix
+
+{ config, lib, pkgs, modulesPath, ... }:
+with lib;
+{
+  imports = [
+    # https://github.com/NixOS/nixpkgs/blob/bebe0f71df8ce8b7912db1853a3fd1d866b38d39/lib/modules.nix#L192
+    (modulesPath + "/profiles/headless.nix")
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  fileSystems."/" = {
+    fsType = "ext4";
+    device = "/dev/disk/by-label/nixos"; # done above
+    autoResize = true;
+  };
+
+  fileSystems."/boot" = {
+    fsType = "vfat";
+    device = "/dev/disk/by-label/UEFI"; # done automatically
+  };
+
+  # This allows an instance to be created with a bigger root filesystem
+  # than provided by the machine image.
+  boot.growPartition = true;
+
+  # Trusting google-compute-config.nix
+  boot.initrd.availableKernelModules = [ "nvme" ];
+  boot.initrd.kernelModules = [ "virtio_scsi" ];
+  boot.kernelParams = [ "console=ttyS0" "panic=1" "boot.panic_on_fail" ];
+  boot.kernelModules = [ "virtio_pci" "virtio_net" ];
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+  boot.loader.timeout = 0;
+  # enable OS Login. This also requires setting enable-oslogin=TRUE metadata on
+  # instance or project level
+  security.googleOsLogin.enable = true;
+  # Use GCE udev rules for dynamic disk volumes
+  services.udev.packages = [ pkgs.google-guest-configs ];
+  services.udev.path = [ pkgs.google-guest-configs ];
+
+  # Force getting the hostname from Google Compute.
+  networking.hostName = "fastly-nixos";
+
+  environment.systemPackages = [
+    pkgs.git
+    pkgs.mosh
+    pkgs.neovim
+    pkgs.tailscale
+    pkgs.wget
+    pkgs.zsh
+  ];
+
+  # Rely on GCP's firewall instead
+  networking.firewall.enable = false;
+
+  # At this point, we are past packer, so we can just rely on tailscale.
+  services.openssh.enable = false;
+  services.openssh.permitRootLogin = "prohibit-password";
+  services.openssh.passwordAuthentication = mkDefault false;
+
+  services.tailscale.enable = true;
+
+  # Configure default metadata hostnames
+  networking.extraHosts = ''
+    169.254.169.254 metadata.google.internal metadata
+  '';
+
+  networking.timeServers = [ "metadata.google.internal" ];
+  networking.usePredictableInterfaceNames = false;
+
+  # GC has 1460 MTU
+  networking.interfaces.eth0.mtu = 1460;
+
+  systemd.packages = [ pkgs.google-guest-agent ];
+
+  systemd.services.google-guest-agent = {
+    wantedBy = [ "multi-user.target" ];
+    restartTriggers = [ config.environment.etc."default/instance_configs.cfg".source ];
+    path = lib.optional config.users.mutableUsers pkgs.shadow;
+  };
+
+  systemd.services.google-startup-scripts.wantedBy = [ "multi-user.target" ];
+  systemd.services.google-shutdown-scripts.wantedBy = [ "multi-user.target" ];
+
+  security.sudo.extraRules = mkIf config.users.mutableUsers [
+    { groups = [ "google-sudoers" ]; commands = [{ command = "ALL"; options = [ "NOPASSWD" ]; }]; }
+  ];
+
+  users.groups.google-sudoers = mkIf config.users.mutableUsers { };
+
+  boot.extraModprobeConfig = lib.readFile "${pkgs.google-guest-configs}/etc/modprobe.d/gce-blacklist.conf";
+
+  environment.etc."sysctl.d/60-gce-network-security.conf".source = "${pkgs.google-guest-configs}/etc/sysctl.d/60-gce-network-security.conf";
+  environment.etc."default/instance_configs.cfg".text = ''
+    [Accounts]
+    useradd_cmd = useradd -m -s /run/current-system/sw/bin/bash -p * {user}
+    [Daemons]
+    accounts_daemon = ${boolToString config.users.mutableUsers}
+    [InstanceSetup]
+    # Make sure GCE image does not replace host key that NixOps sets.
+    set_host_keys = false
+    [MetadataScripts]
+    default_shell = ${pkgs.stdenv.shell}
+    [NetworkInterfaces]
+    dhclient_script = ${pkgs.google-guest-configs}/bin/google-dhclient-script
+    # We set up network interfaces declaratively.
+    setup = false
+  '';
+
+  system.stateVersion = "22.11";
+}

--- a/hosts/ganix/hardware-configuration.nix
+++ b/hosts/ganix/hardware-configuration.nix
@@ -102,6 +102,4 @@ with lib;
     # We set up network interfaces declaratively.
     setup = false
   '';
-
-  system.stateVersion = "22.11";
 }

--- a/hosts/ganix/user.nix
+++ b/hosts/ganix/user.nix
@@ -1,0 +1,23 @@
+{ config
+, lib
+, inputs
+, ...
+}: {
+  imports = [ ../../modules/default.nix ];
+  config.modules = {
+    # gui
+    # TODO
+
+    # cli
+    nvim.enable = true;
+    zsh.enable = true;
+    ssh.enable = true;
+    git.enable = true;
+    gpg.enable = true;
+    tmux.enable = true;
+
+    # system
+    xdg.enable = true;
+    packages.enable = true;
+  };
+}


### PR DESCRIPTION
## NOTES
- `configuration.nix` is mostly copied from [this](https://github.com/NixOS/nixpkgs/blob/nixos-22.11/nixos/modules/virtualisation/google-compute-config.nix)
- On the target, running the following to use these configs:
```bash
nixos-rebuild switch --no-write-lock-file --flake git+https://github.com/mccurdyc/nixos-config.git?ref=ganix#ganix
``` 

## WIP
```
# nixos-rebuild switch --no-write-lock-file --flake git+https://github.com/mccurdyc/nixos-config.git?ref=ganix#ganix
warning: not writing modified lock file of flake 'git+https://github.com/mccurdyc/nixos-config.git?ref=ganix':
• Added input 'flake-utils':
    'github:numtide/flake-utils/5aed5285a952e0b949eb3ba02c12fa4fcfef535f' (2022-11-02)
error: flake 'git+https://github.com/mccurdyc/nixos-config.git?ref=ganix' does not provide attribute 'packages.aarch64-linux.nixosConfigurations."ganix".config.system.build.nixos-rebuild', 'legacyPackages.aarch64-linux.nixosConfigurations."ganix".config.system.build.nixos-rebuild' or 'nixosConfigurations."ganix".config.system.build.nixos-rebuild'
```
- This basically means that my `mkSystem` function isn't outputting appropriate values.
- I bet it's related to this seemingly pointing to nowhere - https://github.com/mccurdyc/nixos-config/blob/a99091ed0b5e9a3f3c5fcd1da0d480de32cc892f/lib/mkSystem.nix#L6